### PR TITLE
Save list title when unfocusing text box

### DIFF
--- a/static/frontend.js
+++ b/static/frontend.js
@@ -66,6 +66,11 @@
                 }
             })
     
+            // Update the title on focus loss
+            this.title.addEventListener('focusout', evt => {
+                this.onChangeTitle(this.title.innerText)
+            })
+
             // Form & Autocomplete
 
             // Add a new item on submit


### PR DESCRIPTION
If a user is changing the name of a list, but instead of pressing enter just clicks elsewhere, the title change is not saved, even though the UI leads to believe the change was saved. This PR fixes that by adding an event handler for focusout.